### PR TITLE
NXP-7954: join gadget: proper message for rejected requests

### DIFF
--- a/nuxeo-social-workspace/nuxeo-social-workspace-core/src/main/java/org/nuxeo/ecm/social/workspace/adapters/SocialWorkspace.java
+++ b/nuxeo-social-workspace/nuxeo-social-workspace-core/src/main/java/org/nuxeo/ecm/social/workspace/adapters/SocialWorkspace.java
@@ -203,6 +203,14 @@ public interface SocialWorkspace {
     boolean isSubscriptionRequestPending(Principal principal);
 
     /**
+     * Returns status of subscription request for the given {@code principal}
+     * Values returned are: pending, accepted, rejected or null if there is no
+     * subscription request
+     * 
+     */
+    String getSubscriptionRequestStatus(Principal principal);
+
+    /**
      * Accepts this {@code subscriptionRequest}.
      */
     void acceptSubscriptionRequest(SubscriptionRequest subscriptionRequest);

--- a/nuxeo-social-workspace/nuxeo-social-workspace-core/src/main/java/org/nuxeo/ecm/social/workspace/adapters/SocialWorkspaceAdapter.java
+++ b/nuxeo-social-workspace/nuxeo-social-workspace-core/src/main/java/org/nuxeo/ecm/social/workspace/adapters/SocialWorkspaceAdapter.java
@@ -234,6 +234,12 @@ public class SocialWorkspaceAdapter extends BaseAdapter implements
     }
 
     @Override
+    public String getSubscriptionRequestStatus(Principal principal) {
+        return getSocialWorkspaceService().getSubscriptionRequestStatus(this,
+                principal);
+    }
+
+    @Override
     public void acceptSubscriptionRequest(
             SubscriptionRequest subscriptionRequest) {
         getSocialWorkspaceService().acceptSubscriptionRequest(this,

--- a/nuxeo-social-workspace/nuxeo-social-workspace-core/src/main/java/org/nuxeo/ecm/social/workspace/service/SocialWorkspaceService.java
+++ b/nuxeo-social-workspace/nuxeo-social-workspace-core/src/main/java/org/nuxeo/ecm/social/workspace/service/SocialWorkspaceService.java
@@ -168,6 +168,15 @@ public interface SocialWorkspaceService {
             Principal principal);
 
     /**
+     * Returns status of subscription request for the given {@code principal}
+     * Values returned are: pending, accepted, rejected or null if there is no
+     * subscription request
+     * 
+     */
+    String getSubscriptionRequestStatus(SocialWorkspace socialWorkspace,
+            Principal principal);
+
+    /**
      * Accepts the {@code subscriptionRequest} for {@code socialWorkspace}.
      */
     void acceptSubscriptionRequest(SocialWorkspace socialWorkspace,

--- a/nuxeo-social-workspace/nuxeo-social-workspace-core/src/main/java/org/nuxeo/ecm/social/workspace/service/SocialWorkspaceServiceImpl.java
+++ b/nuxeo-social-workspace/nuxeo-social-workspace-core/src/main/java/org/nuxeo/ecm/social/workspace/service/SocialWorkspaceServiceImpl.java
@@ -719,6 +719,13 @@ public class SocialWorkspaceServiceImpl extends DefaultComponent implements
     }
 
     @Override
+    public String getSubscriptionRequestStatus(
+            SocialWorkspace socialWorkspace, Principal principal) {
+        return subscriptionRequestHandler.getSubscriptionRequestStatus(
+                socialWorkspace, principal);
+    }
+
+    @Override
     public void acceptSubscriptionRequest(SocialWorkspace socialWorkspace,
             SubscriptionRequest subscriptionRequest) {
         subscriptionRequestHandler.acceptSubscriptionRequest(socialWorkspace,

--- a/nuxeo-social-workspace/nuxeo-social-workspace-core/src/main/java/org/nuxeo/ecm/social/workspace/service/SubscriptionRequestHandler.java
+++ b/nuxeo-social-workspace/nuxeo-social-workspace-core/src/main/java/org/nuxeo/ecm/social/workspace/service/SubscriptionRequestHandler.java
@@ -36,6 +36,9 @@ public interface SubscriptionRequestHandler {
     boolean isSubscriptionRequestPending(SocialWorkspace socialWorkspace,
             Principal principal);
 
+    String getSubscriptionRequestStatus(SocialWorkspace socialWorkspace,
+            Principal principal);
+
     void acceptSubscriptionRequest(SocialWorkspace socialWorkspace,
             SubscriptionRequest subscriptionRequest);
 

--- a/nuxeo-social-workspace/nuxeo-social-workspace-gadgets/src/main/resources/OSGI-INF/l10n/messages.properties
+++ b/nuxeo-social-workspace/nuxeo-social-workspace-gadgets/src/main/resources/OSGI-INF/l10n/messages.properties
@@ -3,6 +3,7 @@ label.gadget.join=Join Us
 label.gadget.joinButton=Join Us
 label.gadget.joinDescription=To join us, please click on button below. A request will be sent to the workspace administrators.
 label.request.registered=Your request has been sent to the social workspace administrators.
+label.request.rejected=Your join request has been rejected.
 label.request.alreadyRegistered=Your join request is waiting for administrators validation.
 label.request.alreadyMember1=Welcome, you have been added to this social workspace. Please click
 label.request.alreadyMember2=here

--- a/nuxeo-social-workspace/nuxeo-social-workspace-gadgets/src/main/resources/OSGI-INF/l10n/messages_en.properties
+++ b/nuxeo-social-workspace/nuxeo-social-workspace-gadgets/src/main/resources/OSGI-INF/l10n/messages_en.properties
@@ -3,6 +3,7 @@ label.gadget.join=Join Us
 label.gadget.joinButton=Join Us
 label.gadget.joinDescription=To join us, please click on button below. A request will be sent to the workspace administrators.
 label.request.registered=Your request has been sent to the social workspace administrators.
+label.request.rejected=Your join request has been rejected.
 label.request.alreadyRegistered=Your join request is waiting for administrators validation.
 label.request.alreadyMember1=Welcome, you have been added to this social workspace. Please click
 label.request.alreadyMember2=here

--- a/nuxeo-social-workspace/nuxeo-social-workspace-gadgets/src/main/resources/OSGI-INF/l10n/messages_fr.properties
+++ b/nuxeo-social-workspace/nuxeo-social-workspace-gadgets/src/main/resources/OSGI-INF/l10n/messages_fr.properties
@@ -3,6 +3,7 @@ label.gadget.join=Nous Rejoindre
 label.gadget.joinButton=Nous rejoindre
 label.gadget.joinDescription=Pour nous rejoindre, cliquez sur le bouton ci-dessous. Une demande sera envoy\u00E9e aux administrateurs de l'espace.
 label.request.registered=Votre demande a \u00E9t\u00E9 envoy\u00E9e \u00E0 l'administrateur de l'espace.
+label.request.rejected=Votre demande d'adh\u00E9sion a \u00E9t\u00E9 rejet\u00E9e.
 label.request.alreadyMember1=Bienvenue ! Vous avez \u00E9t\u00E9 ajout\u00E9 \u00E0 cet espace collaboratif. Merci de cliquer
 label.request.alreadyMember2=ici
 label.request.alreadyMember3=(ce qui vous d\u00E9connectera), puis reconnectez-vous. Vous aurez ainsi acc\u00E8s \u00E0 l'espace priv\u00E9e de l'espace collaboratif.

--- a/nuxeo-social-workspace/nuxeo-social-workspace-gadgets/src/main/resources/gadget/join/dynamic_messages.properties
+++ b/nuxeo-social-workspace/nuxeo-social-workspace-gadgets/src/main/resources/gadget/join/dynamic_messages.properties
@@ -1,6 +1,7 @@
 label.gadget.joinButton=Join us
 label.gadget.joinDescription=To join us, please click on button below. A request will be sent to the workspace administrators.
 label.request.registered=Your request has been sent to the social workspace administrators.
+label.request.rejected=Your join request has been rejected.
 label.request.alreadyRegistered=Your join request is waiting for administrators validation.
 label.request.alreadyMember1=Welcome, you have been added to this social workspace. Please click
 label.request.alreadyMember2=here

--- a/nuxeo-social-workspace/nuxeo-social-workspace-gadgets/src/main/resources/gadget/join/join.xml
+++ b/nuxeo-social-workspace/nuxeo-social-workspace-gadgets/src/main/resources/gadget/join/join.xml
@@ -65,6 +65,10 @@
       _gel("statusMessage").innerHTML = "__MSG_label.request.alreadyRegistered__";
       _gel("joinButton").style.display = 'none';
     }
+    if ( "REQUEST_REJECTED" == status ) {
+      _gel("statusMessage").innerHTML = "__MSG_label.request.rejected__";
+      _gel("joinButton").style.display = 'none';
+    }
     if ( "MEMBER" == status ) {
       var html = '';
       html += '<p>';


### PR DESCRIPTION
added a new method in SocialWorkspaceService to get the user status of the last subscription request 
