### PR TITLE
Do not show Events in the Library Gadget

### DIFF
--- a/nuxeo-social-workspace/nuxeo-social-workspace-gadgets-library/src/main/java/org/nuxeo/ecm/social/workspace/gadgets/webengine/SocialWebEngineRoot.java
+++ b/nuxeo-social-workspace/nuxeo-social-workspace-gadgets-library/src/main/java/org/nuxeo/ecm/social/workspace/gadgets/webengine/SocialWebEngineRoot.java
@@ -421,6 +421,7 @@ public class SocialWebEngineRoot extends ModuleRoot {
                 + "AND ecm:isCheckedInVersion = 0 "
                 + "AND ecm:currentLifeCycleState != 'deleted'"
                 + "AND ecm:parentId = '" + doc.getId() + "' "
+                + "AND ecm:primaryType != 'VEVENT'"
                 + "ORDER BY dc:title";
 
         chain.add(DocumentPageProviderOperation.ID).set("query", query).set(


### PR DESCRIPTION
No workaround for now. Just ignore Events
